### PR TITLE
Select H2 version based on server Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <h2.version>2.3.232</h2.version>
     </properties>
 
 
@@ -144,7 +145,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.3.232</version>
+            <version>${h2.version}</version>
             <scope>compile</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client -->
@@ -200,5 +201,17 @@
         </dependency>
 
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>h2-legacy</id>
+            <activation>
+                <jdk>[1.8,11)</jdk>
+            </activation>
+            <properties>
+                <h2.version>1.4.200</h2.version>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
## Summary
- Select H2 dependency version dynamically from the server's Java version
- Default to H2 2.3.232, falling back to 1.4.200 for Java versions below 11

## Testing
- `mvn -q org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=h2.version -DforceStdout` *(fails: Plugin could not be resolved, network is unreachable)*
- `mvn -q package` *(fails: maven-resources-plugin could not be resolved, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0414787c8324930ca1fed9d09d94